### PR TITLE
concurrentlimit/grpclimit: Add a friendly API for limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM go_dep_downloader AS go_builder
 COPY . .
 RUN go install --mod=readonly -v ./sleepyserver
 
-FROM gcr.io/distroless/base-debian10:nonroot AS subscriber-race
+FROM gcr.io/distroless/base-debian10:nonroot AS sleepyserver
 COPY --from=go_builder /go/bin/sleepyserver /
 ENTRYPOINT ["/sleepyserver"]
 CMD ["--httpAddr=:8080", "--grpcAddr=:8081"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker run -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 --rm -ti --memory=128m 
 
 ## High memory per request
 
-This client makes requests that use 1 MiB/request.
+This client makes requests that use 1 MiB/request. Using 80 concurrent clients reliably blows up the server very quickly. Adding the concurrent rate limiter --concurrentRequests=40 fixes it.
 
 ```
 ulimit -n 10000
@@ -24,8 +24,6 @@ go run ./loadclient/main.go --httpTarget=http://localhost:8080/ --concurrent=80 
 # gRPC
 go run ./loadclient/main.go --grpcTarget=localhost:8081 --concurrent=80 --sleep=3s --waste=1048576 --duration=2m
 ```
-
-This reliably blows up the server very quickly. Adding the concurrent rate limiter --concurrentRequests=40 fixes it.
 
 
 ## Low memory per request (lots of idle requests)

--- a/concurrentlimit.go
+++ b/concurrentlimit.go
@@ -1,0 +1,137 @@
+package concurrentlimit
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/netutil"
+)
+
+var ErrLimited = errors.New("exceeded limit of concurrent operations")
+
+const httpIdleTimeout = time.Minute
+const httpReadHeaderTimeout = time.Minute
+
+// Limiter limits the number of concurrent operations that can be processed.
+type Limiter interface {
+	// Start begins a new operation. It returns a completion function that must be called when the
+	// operation completes, or it returns ErrLimited if no more concurrent operations are allowed.
+	// This should be called as:
+	//
+	// end, err := limiter.Start()
+	// if err != nil {
+	//     // Handle ErrLimited
+	// defer end()
+	Start() (func(), error)
+}
+
+// NoLimit() returns a Limiter that permits an unlimited number of operations.
+func NoLimit() Limiter {
+	return nil
+}
+
+type nilLimiter struct{}
+
+func doNothing() {}
+
+func (n *nilLimiter) start() (func(), error) {
+	return doNothing, nil
+}
+
+// New returns a Limiter that will only permit limit concurrent operations. It will panic if
+// limit is < 0.
+func New(limit int) Limiter {
+	if limit <= 0 {
+		panic(fmt.Sprintf("limit must be > 0: %d", limit))
+	}
+	return &syncLimiter{sync.Mutex{}, limit, 0}
+}
+
+type syncLimiter struct {
+	mu      sync.Mutex
+	max     int
+	current int
+}
+
+func (s *syncLimiter) Start() (func(), error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	next := s.current + 1
+	if next > s.max {
+		return nil, ErrLimited
+	}
+	s.current = next
+
+	return s.end, nil
+}
+
+func (s *syncLimiter) end() {
+	s.mu.Lock()
+	s.current--
+	if s.current < 0 {
+		panic("bug: mismatched calls to start/end")
+	}
+	s.mu.Unlock()
+}
+
+// ListenAndServe listens for HTTP requests with a limited number of concurrent requests
+// and connections. This helps avoid running out of memory during overload situations.
+// Both requestLimit and connectionLimit must be > 0, and connectionLimit must be
+// >= requestLimit. A reasonable defalt is to set the connectionLimit to double the request limit,
+// which assumes that processing each request requires more memory than a raw connection, and that
+// keeping some idle connections is useful.
+//
+// This also sets the server's ReadHeaderTimeout and IdleTimeout to a reasonable default if they
+// are not set, which is an attempt to avoid
+func ListenAndServe(srv *http.Server, requestLimit int, connectionLimit int) error {
+	limitedListener, err := limitListenerForServer(srv, requestLimit, connectionLimit)
+	if err != nil {
+		return err
+	}
+
+	return srv.Serve(limitedListener)
+}
+
+func limitListenerForServer(srv *http.Server, requestLimit int, connectionLimit int) (net.Listener, error) {
+	if requestLimit <= 0 {
+		return nil, fmt.Errorf("ListenAndServe: requestLimit=%d must be > 0", requestLimit)
+	}
+	if connectionLimit < requestLimit {
+		return nil, fmt.Errorf("ListenAndServe: connectionLimit=%d must be >= requestLimit=%d",
+			connectionLimit, requestLimit)
+	}
+	unlimitedListener, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return nil, err
+	}
+	limitedListener := netutil.LimitListener(unlimitedListener, connectionLimit)
+
+	// these are also sane defaults for robustness
+	// https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/
+	if srv.ReadHeaderTimeout <= 0 {
+		srv.ReadHeaderTimeout = httpReadHeaderTimeout
+	}
+	if srv.IdleTimeout <= 0 {
+		srv.IdleTimeout = httpIdleTimeout
+	}
+
+	return limitedListener, nil
+}
+
+// ListenAndServeTLS listens for HTTP requests with a limited number of concurrent requests
+// and connections. See the documentation for ListenAndServe for details.
+func ListenAndServeTLS(
+	srv *http.Server, certFile string, keyFile string, requestLimit int, connectionLimit int,
+) error {
+	limitedListener, err := limitListenerForServer(srv, requestLimit, connectionLimit)
+	if err != nil {
+		return err
+	}
+
+	return srv.ServeTLS(limitedListener, certFile, keyFile)
+}

--- a/concurrentlimit.go
+++ b/concurrentlimit.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/netutil"
 )
 
+// ErrLimited is returned by Limiter when the concurrent operation limit is exceeded.
 var ErrLimited = errors.New("exceeded limit of concurrent operations")
 
 const httpIdleTimeout = time.Minute
@@ -29,7 +30,7 @@ type Limiter interface {
 	Start() (func(), error)
 }
 
-// NoLimit() returns a Limiter that permits an unlimited number of operations.
+// NoLimit returns a Limiter that permits an unlimited number of operations.
 func NoLimit() Limiter {
 	return nil
 }

--- a/grpclimit/grpclimit.go
+++ b/grpclimit/grpclimit.go
@@ -1,0 +1,94 @@
+// Package grpclimit limits the number of concurrent requests and concurrent connections to a gRPC
+// server to ensure that it does not run out of memory during overload scenarios.
+package grpclimit
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/evanj/concurrentlimit"
+	"golang.org/x/net/netutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// LimitedServer contains a grpc.Server and a net.Listener configured to limit concurrent work to
+// prevent running out of memory in overload situations.
+type LimitedServer struct {
+	Server   *grpc.Server
+	Listener net.Listener
+}
+
+// Serve is a convenience function that grpc.Server.Serve with the contained net.Listener.
+func (l *LimitedServer) Serve() error {
+	return l.Server.Serve(l.Listener)
+}
+
+// NewServer creates a grpc.Server and net.Listener that supports a limited number of concurrent
+// requests and connections. It sets the MaxConcurrentStreams option to concurrentRequests, which
+// will cause requests to block on the client if a single client sends too many requests.
+//
+// NOTE: options must not contain any interceptors, since this function relies on adding our
+// own interceptor to limit the requests. Use NewServerWithInterceptors if you need interceptors.
+//
+// TODO: Implement stream interceptors
+func NewServer(
+	addr string, requestLimit int, connectionLimit int, options ...grpc.ServerOption,
+) (*LimitedServer, error) {
+	return NewServerWithInterceptors(addr, requestLimit, connectionLimit, nil, options...)
+}
+
+func NewServerWithInterceptors(
+	addr string, requestLimit int, connectionLimit int, unaryInterceptor grpc.UnaryServerInterceptor,
+	options ...grpc.ServerOption,
+) (*LimitedServer, error) {
+	if requestLimit <= 0 {
+		return nil, fmt.Errorf("NewServer: requestLimit=%d must be > 0", requestLimit)
+	}
+	if connectionLimit < requestLimit {
+		return nil, fmt.Errorf("NewServer: connectionLimit=%d must be >= requestLimit=%d",
+			connectionLimit, requestLimit)
+	}
+
+	unlimitedListener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	limitedListener := netutil.LimitListener(unlimitedListener, connectionLimit)
+
+	requestLimiter := concurrentlimit.New(requestLimit)
+	limitedUnaryInterceptorChain := UnaryLimitInterceptor(requestLimiter, unaryInterceptor)
+
+	options = append(options, grpc.MaxConcurrentStreams(uint32(requestLimit)))
+	options = append(options, grpc.UnaryInterceptor(limitedUnaryInterceptorChain))
+	server := grpc.NewServer(options...)
+
+	return &LimitedServer{server, limitedListener}, nil
+}
+
+// UnaryLimitInterceptor returns a grpc.UnaryServerInterceptor that uses limiter to limit the
+// concurrent requests. It will return codes.ResourcesExceeded if the limiter rejects an operation.
+// If next is not nil, it will be called to chain the request handlers. If it is nil, this will
+// invoke the operation directly.
+func UnaryLimitInterceptor(limiter concurrentlimit.Limiter, next grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		end, err := limiter.Start()
+		if err == concurrentlimit.ErrLimited {
+			return nil, status.Error(codes.ResourceExhausted, err.Error())
+		}
+		if err != nil {
+			return nil, err
+		}
+		defer end()
+
+		if next != nil {
+			return next(ctx, req, info, handler)
+		} else {
+			return handler(ctx, req)
+		}
+	}
+}

--- a/grpclimit/grpclimit.go
+++ b/grpclimit/grpclimit.go
@@ -40,6 +40,9 @@ func NewServer(
 	return NewServerWithInterceptors(addr, requestLimit, connectionLimit, nil, options...)
 }
 
+// NewServerWithInterceptors is a version of NewServer that permits customizing the interceptors.
+// The passed in interceptor will be called after the operation limiter permits the request. See
+// NewServer's documentation for the remaining details.
 func NewServerWithInterceptors(
 	addr string, requestLimit int, connectionLimit int, unaryInterceptor grpc.UnaryServerInterceptor,
 	options ...grpc.ServerOption,
@@ -87,8 +90,7 @@ func UnaryLimitInterceptor(limiter concurrentlimit.Limiter, next grpc.UnaryServe
 
 		if next != nil {
 			return next(ctx, req, info, handler)
-		} else {
-			return handler(ctx, req)
 		}
+		return handler(ctx, req)
 	}
 }


### PR DESCRIPTION
This should make it easier to set up servers that will be memory limited.

limitserver: A copy of sleepyserver that uses the new APIs.