### PR TITLE
Increase idle timeout to 620 seconds to match Google Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Each connection and request that a server is processing takes memory. If you hav
 For a really robust server, you should do the following, in rough priority order:
 
 * Limit concurrent executing requests to limit memory.
-* Limit concurrent connections to limit memory. In particular, Go gRPC connections are very expensive (~180 kiB versus about ~40 kiB per HTTP server connection).
+* Limit concurrent connections to limit memory. In particular, Go gRPC connections are very expensive (~230 kiB versus about ~40 kiB per HTTP server connection, particularly when connections are opening/closing rapidly).
 * Close connections/requests that are too slow or idle, since they are wasting resources.
 * Make clients well-behaved so they reduce their request rate on error, or stop entirely (exponential backoff, back pressure, circuit breakers). The gRPC `MaxConcurrentStreams` setting can help here.
 

--- a/concurrentlimit.go
+++ b/concurrentlimit.go
@@ -17,9 +17,9 @@ var ErrLimited = errors.New("exceeded max concurrent operations limit")
 
 // This should be set longer than what upstream clients/load balancers will use to avoid
 // a "connection race" where the client sends a request at the same time the server is closing
-// it. This can cause errors that may not be retriable. As an example see:
-// https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340?gi=14a65def6148
-const httpIdleTimeout = 10 * time.Minute
+// it. This can cause errors that may not be retriable. This is the value recommended by Google
+// Cloud: https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries
+const httpIdleTimeout = 620 * time.Second
 const httpReadHeaderTimeout = time.Minute
 
 // Limiter limits the number of concurrent operations that can be processed.

--- a/grpclimit/grpclimit.go
+++ b/grpclimit/grpclimit.go
@@ -24,7 +24,9 @@ import (
 // limiting"
 const rateLimitStatus = codes.ResourceExhausted
 
-const idleConnectionTimeout = 10 * time.Minute
+// Set to the value recommended by the Google Cloud Load Balancer:
+// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries
+const idleConnectionTimeout = 620 * time.Second
 const keepaliveTimeout = time.Minute
 
 // NewServer creates a grpc.Server and net.Listener that supports a limited number of concurrent


### PR DESCRIPTION
Hopefully this is long enough to work by default behind most load
balancers.

README.md: Increase gRPC connection memory cost estimate.
sleepyserver: Add pprof handlers for profiling